### PR TITLE
vector: add app/vector module with 5 vector types and Accelerate benchmark

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,8 @@ installer(
         "//:LICENSE.txt",  # if available
         "//app/matrix",  # the target to be installed
         "//app/matrix:matrix_header",  # must be collected in a filegroup
+        "//app/vector",
+        "//app/vector:vector_header",
         "@log",
         "@matio",
         "@openblas//:install_files",

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ It targets macOS and Linux, with CPU acceleration (BLAS/OpenMP) and optional MPS
 ## What is included
 
 - `app/matrix`: dense (`sm`, `dm`) and sparse (`dms`) matrix modules
+- `app/vector`: dense (`sv`, `dv`), strided view (`vv`), sparse (`dvs`) and fixed-size geometry (`vec3`) vector modules
 - `app/matrix:sm_mps`: explicit Apple Silicon MPS path for GPU-resident large
   dense GEMMs; check around `1024^3`, recommended for `2048^3`-class matrices.
 - `app/tensor`: N-dimensional tensor module (`st`) with CPU and optional MPS backend (only on Apple Silicon).
@@ -28,6 +29,7 @@ Build specific modules:
 
 ```bash
 bazel build //app/matrix
+bazel build //app/vector
 bazel build //app/tensor
 ```
 

--- a/app/vector/BUILD
+++ b/app/vector/BUILD
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("//tools:unity_test.bzl", "unity_test")
 
@@ -354,5 +355,17 @@ unity_test(
         ":vector_bridge",
         ":vector_tensor_bridge",
         "//app/tensor:st",
+    ],
+)
+
+cc_binary(
+    name = "bench_sv_dv",
+    srcs = ["tests/bench_sv_dv.c"],
+    copts = default_copts + perf_copts + package_copts,
+    linkopts = accelerate_linkopts + openblas_linkopts,
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [
+        ":dv",
+        ":sv",
     ],
 )

--- a/app/vector/BUILD
+++ b/app/vector/BUILD
@@ -1,0 +1,358 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("//tools:unity_test.bzl", "unity_test")
+
+config_setting(
+    name = "macos_arm64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
+    name = "macos",
+    constraint_values = [
+        "@platforms//os:macos",
+    ],
+)
+
+config_setting(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "linux",
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "backend_accelerate",
+    values = {"define": "MATRIX_BACKEND=accelerate"},
+)
+
+config_setting(
+    name = "backend_openblas",
+    values = {"define": "MATRIX_BACKEND=openblas"},
+)
+
+config_setting(
+    name = "backend_accelerate_macos",
+    constraint_values = [
+        "@platforms//os:macos",
+    ],
+    values = {"define": "MATRIX_BACKEND=accelerate"},
+)
+
+config_setting(
+    name = "backend_openblas_linux",
+    constraint_values = [
+        "@platforms//os:linux",
+    ],
+    values = {"define": "MATRIX_BACKEND=openblas"},
+)
+
+default_copts = [
+    "-Wall",
+    "-Wextra",
+    "-Wpedantic",
+    "-Wconversion",
+    "-Wsign-conversion",
+    "-Wno-c23-extensions",
+    "-Wno-unused-function",
+]
+
+perf_copts = select({
+    ":macos_arm64": [
+        "-O3",
+        "-fvectorize",
+        "-ffast-math",
+        "-funsafe-math-optimizations",
+        "-funroll-loops",
+        "-fomit-frame-pointer",
+        "-march=native",
+    ],
+    ":linux_x86_64": [
+        "-O3",
+        "-ffast-math",
+        "-funsafe-math-optimizations",
+        "-funroll-loops",
+        "-fomit-frame-pointer",
+        "-march=native",
+        "-mtune=native",
+        "-flto",
+        "-fno-math-errno",
+        "-fno-trapping-math",
+        "-falign-functions=32",
+    ],
+    "//conditions:default": [],
+})
+
+package_copts = select({
+    ":backend_accelerate_macos": [
+        "-DUSE_ACCELERATE",
+        "-DACCELERATE_NEW_LAPACK",
+    ],
+    ":backend_openblas_linux": [
+        "-DUSE_OPENBLAS",
+    ],
+    "//conditions:default": [],
+})
+
+openmp_copts = select({
+    ":macos": [
+        "-Xpreprocessor",
+        "-fopenmp",
+    ],
+    ":linux": ["-fopenmp"],
+    "//conditions:default": [],
+})
+
+openmp_linkopts = select({
+    ":linux": [],
+    "//conditions:default": [],
+})
+
+accelerate_linkopts = select({
+    ":backend_accelerate_macos": [
+        "-framework Accelerate",
+        "-lc++abi",
+    ],
+    "//conditions:default": [],
+})
+
+openblas_linkopts = []
+
+default_deps = [
+    "@log",
+    "@openmp//:libomp",
+]
+
+filegroup(
+    name = "vector_header",
+    srcs = glob(["include/*.h"]),
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "sv",
+    srcs = ["src/sv.c"],
+    hdrs = ["include/sv.h"],
+    copts = default_copts + perf_copts + package_copts + openmp_copts,
+    includes = ["include"],
+    linkopts = openmp_linkopts + accelerate_linkopts + openblas_linkopts,
+    target_compatible_with = select({
+        ":backend_accelerate": ["@platforms//os:macos"],
+        ":backend_openblas": ["@platforms//os:linux"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = default_deps + select({
+        ":backend_openblas_linux": ["@openblas"],
+        "//conditions:default": [],
+    }),
+)
+
+cc_library(
+    name = "dv",
+    srcs = ["src/dv.c"],
+    hdrs = ["include/dv.h"],
+    copts = default_copts + perf_copts + package_copts + openmp_copts,
+    includes = ["include"],
+    linkopts = openmp_linkopts + accelerate_linkopts + openblas_linkopts,
+    target_compatible_with = select({
+        ":backend_accelerate": ["@platforms//os:macos"],
+        ":backend_openblas": ["@platforms//os:linux"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = default_deps + select({
+        ":backend_openblas_linux": ["@openblas"],
+        "//conditions:default": [],
+    }),
+)
+
+cc_library(
+    name = "vv",
+    srcs = ["src/vv.c"],
+    hdrs = ["include/vv.h"],
+    copts = default_copts + perf_copts + package_copts + openmp_copts,
+    includes = ["include"],
+    linkopts = openmp_linkopts + accelerate_linkopts + openblas_linkopts,
+    target_compatible_with = select({
+        ":backend_accelerate": ["@platforms//os:macos"],
+        ":backend_openblas": ["@platforms//os:linux"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = default_deps + [
+        ":sv",
+    ] + select({
+        ":backend_openblas_linux": ["@openblas"],
+        "//conditions:default": [],
+    }),
+)
+
+cc_library(
+    name = "dvs",
+    srcs = ["src/dvs.c"],
+    hdrs = ["include/dvs.h"],
+    copts = default_copts + perf_copts + package_copts + openmp_copts,
+    includes = ["include"],
+    linkopts = openmp_linkopts + accelerate_linkopts + openblas_linkopts,
+    target_compatible_with = select({
+        ":backend_accelerate": ["@platforms//os:macos"],
+        ":backend_openblas": ["@platforms//os:linux"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = default_deps + [
+        ":dv",
+    ] + select({
+        ":backend_openblas_linux": ["@openblas"],
+        "//conditions:default": [],
+    }),
+)
+
+cc_library(
+    name = "vec3",
+    srcs = ["src/vec3.c"],
+    hdrs = ["include/vec3.h"],
+    copts = default_copts + perf_copts + package_copts + openmp_copts,
+    includes = ["include"],
+    linkopts = openmp_linkopts + accelerate_linkopts + openblas_linkopts,
+    target_compatible_with = select({
+        ":backend_accelerate": ["@platforms//os:macos"],
+        ":backend_openblas": ["@platforms//os:linux"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = default_deps,
+)
+
+cc_library(
+    name = "vector_bridge",
+    srcs = ["src/vector_bridge.c"],
+    hdrs = ["include/vector_bridge.h"],
+    copts = default_copts + perf_copts + package_copts + openmp_copts,
+    includes = ["include"],
+    linkopts = openmp_linkopts + accelerate_linkopts + openblas_linkopts,
+    target_compatible_with = select({
+        ":backend_accelerate": ["@platforms//os:macos"],
+        ":backend_openblas": ["@platforms//os:linux"],
+        "//conditions:default": [],
+    }),
+    visibility = ["//visibility:public"],
+    deps = default_deps + [
+        ":dv",
+        ":dvs",
+        ":sv",
+        ":vv",
+        "//app/matrix:dm",
+        "//app/matrix:dms",
+        "//app/matrix:sm",
+    ] + select({
+        ":backend_openblas_linux": ["@openblas"],
+        "//conditions:default": [],
+    }),
+)
+
+cc_library(
+    name = "vector_tensor_bridge",
+    srcs = ["src/vector_tensor_bridge.c"],
+    hdrs = ["include/vector_tensor_bridge.h"],
+    copts = default_copts + perf_copts + package_copts + openmp_copts,
+    includes = ["include"],
+    linkopts = openmp_linkopts + accelerate_linkopts + openblas_linkopts,
+    target_compatible_with = ["@platforms//os:macos"],
+    visibility = ["//visibility:public"],
+    deps = default_deps + [
+        ":sv",
+        ":vv",
+        "//app/tensor:st",
+    ] + select({
+        ":backend_openblas_linux": ["@openblas"],
+        "//conditions:default": [],
+    }),
+)
+
+cc_library(
+    name = "vector",
+    hdrs = glob(["include/*.h"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":dv",
+        ":dvs",
+        ":sv",
+        ":vec3",
+        ":vector_bridge",
+        ":vector_tensor_bridge",
+        ":vv",
+    ],
+)
+
+unity_test(
+    name = "test_sv",
+    srcs = ["tests/test_sv.c"],
+    my_config = ["tests/my_config.yml"],
+    tags = ["smoke"],
+    deps = [":sv"],
+)
+
+unity_test(
+    name = "test_dv",
+    srcs = ["tests/test_dv.c"],
+    my_config = ["tests/my_config.yml"],
+    tags = ["smoke"],
+    deps = [":dv"],
+)
+
+unity_test(
+    name = "test_vv",
+    srcs = ["tests/test_vv.c"],
+    my_config = ["tests/my_config.yml"],
+    tags = ["smoke"],
+    deps = [
+        ":sv",
+        ":vector_bridge",
+        ":vv",
+    ],
+)
+
+unity_test(
+    name = "test_dvs",
+    srcs = ["tests/test_dvs.c"],
+    my_config = ["tests/my_config.yml"],
+    tags = ["smoke"],
+    deps = [
+        ":dv",
+        ":dvs",
+    ],
+)
+
+unity_test(
+    name = "test_vec3",
+    srcs = ["tests/test_vec3.c"],
+    my_config = ["tests/my_config.yml"],
+    tags = ["smoke"],
+    deps = [":vec3"],
+)
+
+unity_test(
+    name = "test_vector_bridge",
+    srcs = ["tests/test_vector_bridge.c"],
+    my_config = ["tests/my_config.yml"],
+    tags = ["smoke"],
+    deps = [
+        ":sv",
+        ":vector_bridge",
+        ":vector_tensor_bridge",
+        "//app/tensor:st",
+    ],
+)

--- a/app/vector/include/dv.h
+++ b/app/vector/include/dv.h
@@ -1,0 +1,42 @@
+/**
+ * @file dv.h
+ * @brief Public API for dense double-precision vectors.
+ */
+
+#ifndef DV_H
+#define DV_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct DoubleVector {
+  size_t len;
+  size_t capacity;
+  double *values;
+} DoubleVector;
+
+DoubleVector *dv_create(size_t len);
+DoubleVector *dv_create_with_values(size_t len, const double *values);
+DoubleVector *dv_clone(const DoubleVector *vec);
+double *dv_to_array(const DoubleVector *vec);
+
+double dv_get(const DoubleVector *vec, size_t index);
+bool dv_set(DoubleVector *vec, size_t index, double value);
+bool dv_fill(DoubleVector *vec, double value);
+
+DoubleVector *dv_add(const DoubleVector *lhs, const DoubleVector *rhs);
+DoubleVector *dv_sub(const DoubleVector *lhs, const DoubleVector *rhs);
+DoubleVector *dv_scale(const DoubleVector *vec, double scalar);
+bool dv_axpy(DoubleVector *dst, double alpha, const DoubleVector *src);
+
+double dv_dot(const DoubleVector *lhs, const DoubleVector *rhs);
+double dv_norm_l1(const DoubleVector *vec);
+double dv_norm_l2(const DoubleVector *vec);
+double dv_sum(const DoubleVector *vec);
+double dv_mean(const DoubleVector *vec);
+size_t dv_argmax(const DoubleVector *vec);
+bool dv_normalize(DoubleVector *vec);
+
+void dv_destroy(DoubleVector *vec);
+
+#endif  // DV_H

--- a/app/vector/include/dvs.h
+++ b/app/vector/include/dvs.h
@@ -1,0 +1,34 @@
+/**
+ * @file dvs.h
+ * @brief Public API for sparse double-precision vectors.
+ */
+
+#ifndef DVS_H
+#define DVS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct DoubleVector DoubleVector;
+
+typedef struct DoubleSparseVector {
+  size_t dim;
+  size_t nnz;
+  size_t capacity;
+  size_t *indices;
+  double *values;
+} DoubleSparseVector;
+
+DoubleSparseVector *dvs_create(size_t dim, size_t capacity);
+DoubleSparseVector *dvs_clone(const DoubleSparseVector *vec);
+bool dvs_set(DoubleSparseVector *vec, size_t index, double value);
+double dvs_get(const DoubleSparseVector *vec, size_t index);
+bool dvs_scale(DoubleSparseVector *vec, double scalar);
+bool dvs_sort_indices(DoubleSparseVector *vec);
+bool dvs_compact(DoubleSparseVector *vec);
+DoubleSparseVector *dvs_add(const DoubleSparseVector *lhs,
+                            const DoubleSparseVector *rhs);
+double dvs_dot_dense(const DoubleSparseVector *lhs, const DoubleVector *rhs);
+void dvs_destroy(DoubleSparseVector *vec);
+
+#endif  // DVS_H

--- a/app/vector/include/sv.h
+++ b/app/vector/include/sv.h
@@ -1,0 +1,55 @@
+/**
+ * @file sv.h
+ * @brief Public API for dense single-precision vectors.
+ */
+
+#ifndef SV_H
+#define SV_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum SvBackend {
+  SV_BACKEND_DEFAULT = 0,
+  SV_BACKEND_ACCELERATE = 1,
+  SV_BACKEND_OPENBLAS = 2,
+  SV_BACKEND_OPENMP = 3,
+} SvBackend;
+
+typedef struct FloatVector {
+  size_t len;
+  size_t capacity;
+  float *values;
+} FloatVector;
+
+bool sv_set_backend(SvBackend backend);
+SvBackend sv_get_backend(void);
+const char *sv_active_library(void);
+
+FloatVector *sv_create(size_t len);
+FloatVector *sv_create_with_values(size_t len, const float *values);
+FloatVector *sv_clone(const FloatVector *vec);
+float *sv_to_array(const FloatVector *vec);
+
+float sv_get(const FloatVector *vec, size_t index);
+bool sv_set(FloatVector *vec, size_t index, float value);
+bool sv_fill(FloatVector *vec, float value);
+
+FloatVector *sv_add(const FloatVector *lhs, const FloatVector *rhs);
+FloatVector *sv_sub(const FloatVector *lhs, const FloatVector *rhs);
+FloatVector *sv_scale(const FloatVector *vec, float scalar);
+bool sv_axpy(FloatVector *dst, float alpha, const FloatVector *src);
+
+float sv_dot(const FloatVector *lhs, const FloatVector *rhs);
+float sv_norm_l1(const FloatVector *vec);
+float sv_norm_l2(const FloatVector *vec);
+float sv_sum(const FloatVector *vec);
+float sv_mean(const FloatVector *vec);
+size_t sv_argmax(const FloatVector *vec);
+bool sv_normalize(FloatVector *vec);
+bool sv_softmax(FloatVector *vec);
+
+void sv_destroy(FloatVector *vec);
+
+#endif  // SV_H

--- a/app/vector/include/vec3.h
+++ b/app/vector/include/vec3.h
@@ -1,0 +1,30 @@
+/**
+ * @file vec3.h
+ * @brief Public API for fixed-size 3D geometry vectors.
+ */
+
+#ifndef VEC3_H
+#define VEC3_H
+
+#include <stdbool.h>
+
+typedef struct Vec3 {
+  float x;
+  float y;
+  float z;
+} Vec3;
+
+Vec3 vec3_make(float x, float y, float z);
+Vec3 vec3_add(Vec3 lhs, Vec3 rhs);
+Vec3 vec3_sub(Vec3 lhs, Vec3 rhs);
+Vec3 vec3_scale(Vec3 vec, float scalar);
+float vec3_dot(Vec3 lhs, Vec3 rhs);
+Vec3 vec3_cross(Vec3 lhs, Vec3 rhs);
+float vec3_length(Vec3 vec);
+float vec3_distance(Vec3 lhs, Vec3 rhs);
+bool vec3_normalize(Vec3 *vec);
+Vec3 vec3_lerp(Vec3 lhs, Vec3 rhs, float t);
+Vec3 vec3_project(Vec3 vec, Vec3 onto);
+Vec3 vec3_reflect(Vec3 incident, Vec3 normal);
+
+#endif  // VEC3_H

--- a/app/vector/include/vector_bridge.h
+++ b/app/vector/include/vector_bridge.h
@@ -1,0 +1,32 @@
+/**
+ * @file vector_bridge.h
+ * @brief Bridge helpers between vectors, matrices, sparse matrices, and tensors.
+ */
+
+#ifndef VECTOR_BRIDGE_H
+#define VECTOR_BRIDGE_H
+
+#include "dm.h"
+#include "dms.h"
+#include "dv.h"
+#include "dvs.h"
+#include "sm.h"
+#include "sv.h"
+#include "vv.h"
+
+FloatVectorView sm_row_view(FloatMatrix *mat, size_t row);
+FloatVectorView sm_col_view(FloatMatrix *mat, size_t col);
+FloatVector *sm_row_to_sv(const FloatMatrix *mat, size_t row);
+FloatVector *sm_col_to_sv(const FloatMatrix *mat, size_t col);
+FloatVector *sm_matvec(const FloatMatrix *mat, const FloatVector *vec);
+FloatMatrix *sv_outer_as_sm(const FloatVector *lhs, const FloatVector *rhs);
+
+DoubleVector *dm_row_to_dv(const DoubleMatrix *mat, size_t row);
+DoubleVector *dm_col_to_dv(const DoubleMatrix *mat, size_t col);
+DoubleVector *dm_matvec(const DoubleMatrix *mat, const DoubleVector *vec);
+DoubleMatrix *dv_outer_as_dm(const DoubleVector *lhs, const DoubleVector *rhs);
+
+DoubleSparseVector *dms_row_to_dvs(const DoubleSparseMatrix *mat, size_t row);
+DoubleSparseVector *dms_col_to_dvs(const DoubleSparseMatrix *mat, size_t col);
+
+#endif  // VECTOR_BRIDGE_H

--- a/app/vector/include/vector_tensor_bridge.h
+++ b/app/vector/include/vector_tensor_bridge.h
@@ -1,0 +1,16 @@
+/**
+ * @file vector_tensor_bridge.h
+ * @brief Tensor-specific bridge helpers for vector views and copies.
+ */
+
+#ifndef VECTOR_TENSOR_BRIDGE_H
+#define VECTOR_TENSOR_BRIDGE_H
+
+#include "st.h"
+#include "sv.h"
+#include "vv.h"
+
+FloatVectorView st_as_vv_view(FloatTensor *tensor);
+FloatVector *st_to_sv(const FloatTensor *tensor);
+
+#endif  // VECTOR_TENSOR_BRIDGE_H

--- a/app/vector/include/vv.h
+++ b/app/vector/include/vv.h
@@ -1,0 +1,29 @@
+/**
+ * @file vv.h
+ * @brief Public API for non-owning strided float vector views.
+ */
+
+#ifndef VV_H
+#define VV_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct FloatVector FloatVector;
+
+typedef struct FloatVectorView {
+  size_t len;
+  ptrdiff_t stride;
+  float *values;
+} FloatVectorView;
+
+FloatVectorView vv_make(float *data, size_t len, ptrdiff_t stride);
+bool vv_is_valid(const FloatVectorView *view);
+float vv_get(const FloatVectorView *view, size_t index);
+bool vv_set(FloatVectorView *view, size_t index, float value);
+float vv_dot(const FloatVectorView *lhs, const FloatVectorView *rhs);
+float vv_norm_l2(const FloatVectorView *view);
+FloatVector *vv_to_sv(const FloatVectorView *view);
+bool vv_copy_from_sv(FloatVectorView *dst, const FloatVector *src);
+
+#endif  // VV_H

--- a/app/vector/src/dv.c
+++ b/app/vector/src/dv.c
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2026 @tragisch <https://github.com/tragisch>
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "dv.h"
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#endif
+#include <omp.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(USE_ACCELERATE)
+#define BLASINT int
+#include <Accelerate/Accelerate.h>
+#elif defined(USE_OPENBLAS)
+#define BLASINT int
+#include <cblas.h>
+#endif
+
+static const double DV_EPSILON = 1e-12;
+
+static bool dv_has_compatible_shape(const DoubleVector *lhs,
+                                    const DoubleVector *rhs) {
+  return lhs != NULL && rhs != NULL && lhs->len == rhs->len &&
+         lhs->values != NULL && rhs->values != NULL;
+}
+
+static DoubleVector *dv_create_uninitialized(size_t len) {
+  DoubleVector *vec = (DoubleVector *)malloc(sizeof(DoubleVector));
+  if (vec == NULL) {
+    return NULL;
+  }
+  vec->len = len;
+  vec->capacity = len;
+  vec->values = len == 0 ? NULL : (double *)malloc(len * sizeof(double));
+  if (len > 0 && vec->values == NULL) {
+    free(vec);
+    return NULL;
+  }
+  return vec;
+}
+
+DoubleVector *dv_create(size_t len) {
+  DoubleVector *vec = dv_create_uninitialized(len);
+  if (vec == NULL) {
+    return NULL;
+  }
+  if (len > 0) {
+    memset(vec->values, 0, len * sizeof(double));
+  }
+  return vec;
+}
+
+DoubleVector *dv_create_with_values(size_t len, const double *values) {
+  if (len > 0 && values == NULL) {
+    return NULL;
+  }
+  DoubleVector *vec = dv_create_uninitialized(len);
+  if (vec == NULL) {
+    return NULL;
+  }
+  if (len > 0) {
+    memcpy(vec->values, values, len * sizeof(double));
+  }
+  return vec;
+}
+
+DoubleVector *dv_clone(const DoubleVector *vec) {
+  if (vec == NULL) {
+    return NULL;
+  }
+  return dv_create_with_values(vec->len, vec->values);
+}
+
+double *dv_to_array(const DoubleVector *vec) {
+  if (vec == NULL || vec->len == 0 || vec->values == NULL) {
+    return NULL;
+  }
+  double *copy = (double *)malloc(vec->len * sizeof(double));
+  if (copy == NULL) {
+    return NULL;
+  }
+  memcpy(copy, vec->values, vec->len * sizeof(double));
+  return copy;
+}
+
+double dv_get(const DoubleVector *vec, size_t index) {
+  return (vec == NULL || vec->values == NULL || index >= vec->len)
+             ? 0.0
+             : vec->values[index];
+}
+
+bool dv_set(DoubleVector *vec, size_t index, double value) {
+  if (vec == NULL || vec->values == NULL || index >= vec->len) {
+    return false;
+  }
+  vec->values[index] = value;
+  return true;
+}
+
+bool dv_fill(DoubleVector *vec, double value) {
+  if (vec == NULL || (vec->len > 0 && vec->values == NULL)) {
+    return false;
+  }
+  for (size_t i = 0; i < vec->len; ++i) {
+    vec->values[i] = value;
+  }
+  return true;
+}
+
+DoubleVector *dv_add(const DoubleVector *lhs, const DoubleVector *rhs) {
+  if (!dv_has_compatible_shape(lhs, rhs)) {
+    return NULL;
+  }
+  DoubleVector *out = dv_clone(lhs);
+  if (out == NULL) {
+    return NULL;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  cblas_daxpy((BLASINT)lhs->len, 1.0, rhs->values, 1, out->values, 1);
+#else
+#pragma omp parallel for simd
+  for (size_t i = 0; i < lhs->len; ++i) {
+    out->values[i] += rhs->values[i];
+  }
+#endif
+  return out;
+}
+
+DoubleVector *dv_sub(const DoubleVector *lhs, const DoubleVector *rhs) {
+  if (!dv_has_compatible_shape(lhs, rhs)) {
+    return NULL;
+  }
+  DoubleVector *out = dv_clone(lhs);
+  if (out == NULL) {
+    return NULL;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  cblas_daxpy((BLASINT)lhs->len, -1.0, rhs->values, 1, out->values, 1);
+#else
+#pragma omp parallel for simd
+  for (size_t i = 0; i < lhs->len; ++i) {
+    out->values[i] -= rhs->values[i];
+  }
+#endif
+  return out;
+}
+
+DoubleVector *dv_scale(const DoubleVector *vec, double scalar) {
+  if (vec == NULL || (vec->len > 0 && vec->values == NULL)) {
+    return NULL;
+  }
+  DoubleVector *out = dv_clone(vec);
+  if (out == NULL) {
+    return NULL;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  cblas_dscal((BLASINT)out->len, scalar, out->values, 1);
+#else
+#pragma omp parallel for simd
+  for (size_t i = 0; i < out->len; ++i) {
+    out->values[i] *= scalar;
+  }
+#endif
+  return out;
+}
+
+bool dv_axpy(DoubleVector *dst, double alpha, const DoubleVector *src) {
+  if (!dv_has_compatible_shape(dst, src)) {
+    return false;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  cblas_daxpy((BLASINT)dst->len, alpha, src->values, 1, dst->values, 1);
+#else
+#pragma omp parallel for simd
+  for (size_t i = 0; i < dst->len; ++i) {
+    dst->values[i] += alpha * src->values[i];
+  }
+#endif
+  return true;
+}
+
+double dv_dot(const DoubleVector *lhs, const DoubleVector *rhs) {
+  if (!dv_has_compatible_shape(lhs, rhs)) {
+    return 0.0;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  return cblas_ddot((BLASINT)lhs->len, lhs->values, 1, rhs->values, 1);
+#else
+  double sum = 0.0;
+#pragma omp parallel for simd reduction(+ : sum)
+  for (size_t i = 0; i < lhs->len; ++i) {
+    sum += lhs->values[i] * rhs->values[i];
+  }
+  return sum;
+#endif
+}
+
+double dv_norm_l1(const DoubleVector *vec) {
+  if (vec == NULL || (vec->len > 0 && vec->values == NULL)) {
+    return 0.0;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  return cblas_dasum((BLASINT)vec->len, vec->values, 1);
+#else
+  double sum = 0.0;
+#pragma omp parallel for simd reduction(+ : sum)
+  for (size_t i = 0; i < vec->len; ++i) {
+    sum += fabs(vec->values[i]);
+  }
+  return sum;
+#endif
+}
+
+double dv_norm_l2(const DoubleVector *vec) {
+  if (vec == NULL || (vec->len > 0 && vec->values == NULL)) {
+    return 0.0;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  return cblas_dnrm2((BLASINT)vec->len, vec->values, 1);
+#else
+  double sum = 0.0;
+#pragma omp parallel for simd reduction(+ : sum)
+  for (size_t i = 0; i < vec->len; ++i) {
+    sum += vec->values[i] * vec->values[i];
+  }
+  return sqrt(sum);
+#endif
+}
+
+double dv_sum(const DoubleVector *vec) {
+  if (vec == NULL || (vec->len > 0 && vec->values == NULL)) {
+    return 0.0;
+  }
+  double sum = 0.0;
+#pragma omp parallel for simd reduction(+ : sum)
+  for (size_t i = 0; i < vec->len; ++i) {
+    sum += vec->values[i];
+  }
+  return sum;
+}
+
+double dv_mean(const DoubleVector *vec) {
+  if (vec == NULL || vec->len == 0) {
+    return 0.0;
+  }
+  return dv_sum(vec) / (double)vec->len;
+}
+
+size_t dv_argmax(const DoubleVector *vec) {
+  if (vec == NULL || vec->len == 0 || vec->values == NULL) {
+    return (size_t)-1;
+  }
+  size_t best = 0;
+  for (size_t i = 1; i < vec->len; ++i) {
+    if (vec->values[i] > vec->values[best]) {
+      best = i;
+    }
+  }
+  return best;
+}
+
+bool dv_normalize(DoubleVector *vec) {
+  if (vec == NULL || vec->values == NULL) {
+    return false;
+  }
+  double norm = dv_norm_l2(vec);
+  if (norm <= DV_EPSILON) {
+    return false;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  cblas_dscal((BLASINT)vec->len, 1.0 / norm, vec->values, 1);
+#else
+  double inv = 1.0 / norm;
+#pragma omp parallel for simd
+  for (size_t i = 0; i < vec->len; ++i) {
+    vec->values[i] *= inv;
+  }
+#endif
+  return true;
+}
+
+void dv_destroy(DoubleVector *vec) {
+  if (vec == NULL) {
+    return;
+  }
+  free(vec->values);
+  free(vec);
+}

--- a/app/vector/src/dvs.c
+++ b/app/vector/src/dvs.c
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2026 @tragisch <https://github.com/tragisch>
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "dvs.h"
+
+#include "dv.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct DvsPair {
+  size_t index;
+  double value;
+} DvsPair;
+
+static int dvs_pair_compare(const void *lhs, const void *rhs) {
+  const DvsPair *a = (const DvsPair *)lhs;
+  const DvsPair *b = (const DvsPair *)rhs;
+  if (a->index < b->index) {
+    return -1;
+  }
+  if (a->index > b->index) {
+    return 1;
+  }
+  return 0;
+}
+
+static bool dvs_ensure_capacity(DoubleSparseVector *vec, size_t min_capacity) {
+  if (vec == NULL) {
+    return false;
+  }
+  if (vec->capacity >= min_capacity) {
+    return true;
+  }
+  size_t new_capacity = vec->capacity == 0 ? 1 : vec->capacity;
+  while (new_capacity < min_capacity) {
+    new_capacity *= 2;
+  }
+  size_t *new_indices =
+      (size_t *)realloc(vec->indices, new_capacity * sizeof(size_t));
+  if (new_indices == NULL) {
+    return false;
+  }
+  double *new_values =
+      (double *)realloc(vec->values, new_capacity * sizeof(double));
+  if (new_values == NULL) {
+    vec->indices = new_indices;
+    return false;
+  }
+  vec->indices = new_indices;
+  vec->values = new_values;
+  vec->capacity = new_capacity;
+  return true;
+}
+
+DoubleSparseVector *dvs_create(size_t dim, size_t capacity) {
+  DoubleSparseVector *vec =
+      (DoubleSparseVector *)calloc(1, sizeof(DoubleSparseVector));
+  if (vec == NULL) {
+    return NULL;
+  }
+  vec->dim = dim;
+  vec->capacity = capacity;
+  if (capacity > 0) {
+    vec->indices = (size_t *)malloc(capacity * sizeof(size_t));
+    vec->values = (double *)malloc(capacity * sizeof(double));
+    if (vec->indices == NULL || vec->values == NULL) {
+      free(vec->indices);
+      free(vec->values);
+      free(vec);
+      return NULL;
+    }
+  }
+  return vec;
+}
+
+DoubleSparseVector *dvs_clone(const DoubleSparseVector *vec) {
+  if (vec == NULL) {
+    return NULL;
+  }
+  DoubleSparseVector *copy = dvs_create(vec->dim, vec->nnz);
+  if (copy == NULL) {
+    return NULL;
+  }
+  copy->nnz = vec->nnz;
+  if (vec->nnz > 0) {
+    memcpy(copy->indices, vec->indices, vec->nnz * sizeof(size_t));
+    memcpy(copy->values, vec->values, vec->nnz * sizeof(double));
+  }
+  return copy;
+}
+
+bool dvs_set(DoubleSparseVector *vec, size_t index, double value) {
+  if (vec == NULL || index >= vec->dim) {
+    return false;
+  }
+  for (size_t i = 0; i < vec->nnz; ++i) {
+    if (vec->indices[i] == index) {
+      if (value == 0.0) {
+        if (i + 1 < vec->nnz) {
+          memmove(&vec->indices[i], &vec->indices[i + 1],
+                  (vec->nnz - i - 1) * sizeof(size_t));
+          memmove(&vec->values[i], &vec->values[i + 1],
+                  (vec->nnz - i - 1) * sizeof(double));
+        }
+        vec->nnz--;
+        return true;
+      }
+      vec->values[i] = value;
+      return true;
+    }
+  }
+  if (value == 0.0) {
+    return true;
+  }
+  if (!dvs_ensure_capacity(vec, vec->nnz + 1)) {
+    return false;
+  }
+  vec->indices[vec->nnz] = index;
+  vec->values[vec->nnz] = value;
+  vec->nnz++;
+  return true;
+}
+
+double dvs_get(const DoubleSparseVector *vec, size_t index) {
+  if (vec == NULL || index >= vec->dim) {
+    return 0.0;
+  }
+  for (size_t i = 0; i < vec->nnz; ++i) {
+    if (vec->indices[i] == index) {
+      return vec->values[i];
+    }
+  }
+  return 0.0;
+}
+
+bool dvs_scale(DoubleSparseVector *vec, double scalar) {
+  if (vec == NULL) {
+    return false;
+  }
+  for (size_t i = 0; i < vec->nnz; ++i) {
+    vec->values[i] *= scalar;
+  }
+  return true;
+}
+
+bool dvs_sort_indices(DoubleSparseVector *vec) {
+  if (vec == NULL || vec->nnz < 2) {
+    return vec != NULL;
+  }
+  DvsPair *pairs = (DvsPair *)malloc(vec->nnz * sizeof(DvsPair));
+  if (pairs == NULL) {
+    return false;
+  }
+  for (size_t i = 0; i < vec->nnz; ++i) {
+    pairs[i].index = vec->indices[i];
+    pairs[i].value = vec->values[i];
+  }
+  qsort(pairs, vec->nnz, sizeof(DvsPair), dvs_pair_compare);
+  for (size_t i = 0; i < vec->nnz; ++i) {
+    vec->indices[i] = pairs[i].index;
+    vec->values[i] = pairs[i].value;
+  }
+  free(pairs);
+  return true;
+}
+
+bool dvs_compact(DoubleSparseVector *vec) {
+  if (vec == NULL) {
+    return false;
+  }
+  if (!dvs_sort_indices(vec)) {
+    return false;
+  }
+  size_t write = 0;
+  for (size_t i = 0; i < vec->nnz; ++i) {
+    if (write > 0 && vec->indices[write - 1] == vec->indices[i]) {
+      vec->values[write - 1] += vec->values[i];
+      continue;
+    }
+    vec->indices[write] = vec->indices[i];
+    vec->values[write] = vec->values[i];
+    write++;
+  }
+  size_t compacted = 0;
+  for (size_t i = 0; i < write; ++i) {
+    if (vec->values[i] != 0.0) {
+      vec->indices[compacted] = vec->indices[i];
+      vec->values[compacted] = vec->values[i];
+      compacted++;
+    }
+  }
+  vec->nnz = compacted;
+  return true;
+}
+
+DoubleSparseVector *dvs_add(const DoubleSparseVector *lhs,
+                            const DoubleSparseVector *rhs) {
+  if (lhs == NULL || rhs == NULL || lhs->dim != rhs->dim) {
+    return NULL;
+  }
+  DoubleSparseVector *out = dvs_clone(lhs);
+  if (out == NULL) {
+    return NULL;
+  }
+  if (!dvs_ensure_capacity(out, lhs->nnz + rhs->nnz)) {
+    dvs_destroy(out);
+    return NULL;
+  }
+  for (size_t i = 0; i < rhs->nnz; ++i) {
+    if (!dvs_set(out, rhs->indices[i], dvs_get(out, rhs->indices[i]) + rhs->values[i])) {
+      dvs_destroy(out);
+      return NULL;
+    }
+  }
+  if (!dvs_compact(out)) {
+    dvs_destroy(out);
+    return NULL;
+  }
+  return out;
+}
+
+double dvs_dot_dense(const DoubleSparseVector *lhs, const DoubleVector *rhs) {
+  if (lhs == NULL || rhs == NULL || rhs->values == NULL || lhs->dim != rhs->len) {
+    return 0.0;
+  }
+  double sum = 0.0;
+  for (size_t i = 0; i < lhs->nnz; ++i) {
+    sum += lhs->values[i] * rhs->values[lhs->indices[i]];
+  }
+  return sum;
+}
+
+void dvs_destroy(DoubleSparseVector *vec) {
+  if (vec == NULL) {
+    return;
+  }
+  free(vec->indices);
+  free(vec->values);
+  free(vec);
+}

--- a/app/vector/src/sv.c
+++ b/app/vector/src/sv.c
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) 2026 @tragisch <https://github.com/tragisch>
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "sv.h"
+
+#include <log.h>
+#include <math.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#endif
+#include <omp.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(USE_ACCELERATE)
+#define BLASINT int
+#include <Accelerate/Accelerate.h>
+#elif defined(USE_OPENBLAS)
+#define BLASINT int
+#include <cblas.h>
+#endif
+
+static const float SV_EPSILON = 1e-8f;
+static SvBackend sv_current_backend = SV_BACKEND_DEFAULT;
+
+static bool sv_has_compatible_shape(const FloatVector *lhs,
+                                    const FloatVector *rhs) {
+  return lhs != NULL && rhs != NULL && lhs->len == rhs->len &&
+         lhs->values != NULL && rhs->values != NULL;
+}
+
+static FloatVector *sv_create_uninitialized(size_t len) {
+  FloatVector *vec = (FloatVector *)malloc(sizeof(FloatVector));
+  if (vec == NULL) {
+    log_error("Failed to allocate float vector metadata");
+    return NULL;
+  }
+  vec->len = len;
+  vec->capacity = len;
+  vec->values = len == 0 ? NULL : (float *)malloc(len * sizeof(float));
+  if (len > 0 && vec->values == NULL) {
+    log_error("Failed to allocate float vector values");
+    free(vec);
+    return NULL;
+  }
+  return vec;
+}
+
+bool sv_set_backend(SvBackend backend) {
+  switch (backend) {
+    case SV_BACKEND_DEFAULT:
+      sv_current_backend = backend;
+      return true;
+    case SV_BACKEND_ACCELERATE:
+#if defined(USE_ACCELERATE)
+      sv_current_backend = backend;
+      return true;
+#else
+      return false;
+#endif
+    case SV_BACKEND_OPENBLAS:
+#if defined(USE_OPENBLAS)
+      sv_current_backend = backend;
+      return true;
+#else
+      return false;
+#endif
+    case SV_BACKEND_OPENMP:
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+      return false;
+#else
+      sv_current_backend = backend;
+      return true;
+#endif
+  }
+  return false;
+}
+
+SvBackend sv_get_backend(void) { return sv_current_backend; }
+
+const char *sv_active_library(void) {
+  switch (sv_current_backend) {
+    case SV_BACKEND_ACCELERATE:
+#if defined(USE_ACCELERATE)
+      return "Apple Accelerate";
+#endif
+      break;
+    case SV_BACKEND_OPENBLAS:
+#if defined(USE_OPENBLAS)
+      return "OpenBLAS";
+#endif
+      break;
+    case SV_BACKEND_OPENMP:
+      return "OpenMP";
+    case SV_BACKEND_DEFAULT:
+    default:
+      break;
+  }
+#if defined(USE_ACCELERATE)
+  return "Apple Accelerate";
+#elif defined(USE_OPENBLAS)
+  return "OpenBLAS";
+#else
+  return "OpenMP";
+#endif
+}
+
+FloatVector *sv_create(size_t len) {
+  FloatVector *vec = sv_create_uninitialized(len);
+  if (vec == NULL) {
+    return NULL;
+  }
+  if (len > 0) {
+    memset(vec->values, 0, len * sizeof(float));
+  }
+  return vec;
+}
+
+FloatVector *sv_create_with_values(size_t len, const float *values) {
+  if (len > 0 && values == NULL) {
+    return NULL;
+  }
+  FloatVector *vec = sv_create_uninitialized(len);
+  if (vec == NULL) {
+    return NULL;
+  }
+  if (len > 0) {
+    memcpy(vec->values, values, len * sizeof(float));
+  }
+  return vec;
+}
+
+FloatVector *sv_clone(const FloatVector *vec) {
+  if (vec == NULL) {
+    return NULL;
+  }
+  return sv_create_with_values(vec->len, vec->values);
+}
+
+float *sv_to_array(const FloatVector *vec) {
+  if (vec == NULL) {
+    return NULL;
+  }
+  if (vec->len == 0) {
+    return NULL;
+  }
+  float *copy = (float *)malloc(vec->len * sizeof(float));
+  if (copy == NULL) {
+    return NULL;
+  }
+  memcpy(copy, vec->values, vec->len * sizeof(float));
+  return copy;
+}
+
+float sv_get(const FloatVector *vec, size_t index) {
+  return (vec == NULL || vec->values == NULL || index >= vec->len)
+             ? 0.0f
+             : vec->values[index];
+}
+
+bool sv_set(FloatVector *vec, size_t index, float value) {
+  if (vec == NULL || vec->values == NULL || index >= vec->len) {
+    return false;
+  }
+  vec->values[index] = value;
+  return true;
+}
+
+bool sv_fill(FloatVector *vec, float value) {
+  if (vec == NULL || (vec->len > 0 && vec->values == NULL)) {
+    return false;
+  }
+  for (size_t i = 0; i < vec->len; ++i) {
+    vec->values[i] = value;
+  }
+  return true;
+}
+
+FloatVector *sv_add(const FloatVector *lhs, const FloatVector *rhs) {
+  if (!sv_has_compatible_shape(lhs, rhs)) {
+    return NULL;
+  }
+  FloatVector *out = sv_create(lhs->len);
+  if (out == NULL) {
+    return NULL;
+  }
+  memcpy(out->values, lhs->values, lhs->len * sizeof(float));
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  cblas_saxpy((BLASINT)lhs->len, 1.0f, rhs->values, 1, out->values, 1);
+#else
+#pragma omp parallel for simd
+  for (size_t i = 0; i < lhs->len; ++i) {
+    out->values[i] += rhs->values[i];
+  }
+#endif
+  return out;
+}
+
+FloatVector *sv_sub(const FloatVector *lhs, const FloatVector *rhs) {
+  if (!sv_has_compatible_shape(lhs, rhs)) {
+    return NULL;
+  }
+  FloatVector *out = sv_create(lhs->len);
+  if (out == NULL) {
+    return NULL;
+  }
+  memcpy(out->values, lhs->values, lhs->len * sizeof(float));
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  cblas_saxpy((BLASINT)lhs->len, -1.0f, rhs->values, 1, out->values, 1);
+#else
+#pragma omp parallel for simd
+  for (size_t i = 0; i < lhs->len; ++i) {
+    out->values[i] -= rhs->values[i];
+  }
+#endif
+  return out;
+}
+
+FloatVector *sv_scale(const FloatVector *vec, float scalar) {
+  if (vec == NULL || (vec->len > 0 && vec->values == NULL)) {
+    return NULL;
+  }
+  FloatVector *out = sv_clone(vec);
+  if (out == NULL) {
+    return NULL;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  cblas_sscal((BLASINT)out->len, scalar, out->values, 1);
+#else
+#pragma omp parallel for simd
+  for (size_t i = 0; i < out->len; ++i) {
+    out->values[i] *= scalar;
+  }
+#endif
+  return out;
+}
+
+bool sv_axpy(FloatVector *dst, float alpha, const FloatVector *src) {
+  if (!sv_has_compatible_shape(dst, src)) {
+    return false;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  cblas_saxpy((BLASINT)dst->len, alpha, src->values, 1, dst->values, 1);
+#else
+#pragma omp parallel for simd
+  for (size_t i = 0; i < dst->len; ++i) {
+    dst->values[i] += alpha * src->values[i];
+  }
+#endif
+  return true;
+}
+
+float sv_dot(const FloatVector *lhs, const FloatVector *rhs) {
+  if (!sv_has_compatible_shape(lhs, rhs)) {
+    return 0.0f;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  return cblas_sdot((BLASINT)lhs->len, lhs->values, 1, rhs->values, 1);
+#else
+  float sum = 0.0f;
+#pragma omp parallel for simd reduction(+ : sum)
+  for (size_t i = 0; i < lhs->len; ++i) {
+    sum += lhs->values[i] * rhs->values[i];
+  }
+  return sum;
+#endif
+}
+
+float sv_norm_l1(const FloatVector *vec) {
+  if (vec == NULL || (vec->len > 0 && vec->values == NULL)) {
+    return 0.0f;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  return cblas_sasum((BLASINT)vec->len, vec->values, 1);
+#else
+  float sum = 0.0f;
+#pragma omp parallel for simd reduction(+ : sum)
+  for (size_t i = 0; i < vec->len; ++i) {
+    sum += fabsf(vec->values[i]);
+  }
+  return sum;
+#endif
+}
+
+float sv_norm_l2(const FloatVector *vec) {
+  if (vec == NULL || (vec->len > 0 && vec->values == NULL)) {
+    return 0.0f;
+  }
+#if defined(USE_ACCELERATE)
+  return cblas_snrm2((BLASINT)vec->len, vec->values, 1);
+#elif defined(USE_OPENBLAS)
+  return cblas_snrm2((BLASINT)vec->len, vec->values, 1);
+#else
+  float sum = 0.0f;
+#pragma omp parallel for simd reduction(+ : sum)
+  for (size_t i = 0; i < vec->len; ++i) {
+    sum += vec->values[i] * vec->values[i];
+  }
+  return sqrtf(sum);
+#endif
+}
+
+float sv_sum(const FloatVector *vec) {
+  if (vec == NULL || (vec->len > 0 && vec->values == NULL)) {
+    return 0.0f;
+  }
+#if defined(USE_ACCELERATE)
+  float sum = 0.0f;
+  vDSP_sve(vec->values, 1, &sum, (vDSP_Length)vec->len);
+  return sum;
+#else
+  float sum = 0.0f;
+#pragma omp parallel for simd reduction(+ : sum)
+  for (size_t i = 0; i < vec->len; ++i) {
+    sum += vec->values[i];
+  }
+  return sum;
+#endif
+}
+
+float sv_mean(const FloatVector *vec) {
+  if (vec == NULL || vec->len == 0) {
+    return 0.0f;
+  }
+  return sv_sum(vec) / (float)vec->len;
+}
+
+size_t sv_argmax(const FloatVector *vec) {
+  if (vec == NULL || vec->len == 0 || vec->values == NULL) {
+    return (size_t)-1;
+  }
+  size_t best = 0;
+  for (size_t i = 1; i < vec->len; ++i) {
+    if (vec->values[i] > vec->values[best]) {
+      best = i;
+    }
+  }
+  return best;
+}
+
+bool sv_normalize(FloatVector *vec) {
+  if (vec == NULL || vec->values == NULL) {
+    return false;
+  }
+  float norm = sv_norm_l2(vec);
+  if (norm <= SV_EPSILON) {
+    return false;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  float scale = 1.0f / norm;
+  cblas_sscal((BLASINT)vec->len, scale, vec->values, 1);
+#else
+  float inv = 1.0f / norm;
+#pragma omp parallel for simd
+  for (size_t i = 0; i < vec->len; ++i) {
+    vec->values[i] *= inv;
+  }
+#endif
+  return true;
+}
+
+bool sv_softmax(FloatVector *vec) {
+  if (vec == NULL || vec->len == 0 || vec->values == NULL) {
+    return false;
+  }
+  size_t max_index = sv_argmax(vec);
+  if (max_index == (size_t)-1) {
+    return false;
+  }
+  float max_value = vec->values[max_index];
+  float sum = 0.0f;
+  for (size_t i = 0; i < vec->len; ++i) {
+    vec->values[i] = expf(vec->values[i] - max_value);
+    sum += vec->values[i];
+  }
+  if (sum <= SV_EPSILON) {
+    return false;
+  }
+#pragma omp parallel for simd
+  for (size_t i = 0; i < vec->len; ++i) {
+    vec->values[i] /= sum;
+  }
+  return true;
+}
+
+void sv_destroy(FloatVector *vec) {
+  if (vec == NULL) {
+    return;
+  }
+  free(vec->values);
+  free(vec);
+}

--- a/app/vector/src/vec3.c
+++ b/app/vector/src/vec3.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 @tragisch <https://github.com/tragisch>
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "vec3.h"
+
+#include <math.h>
+#include <stddef.h>
+#include <stddef.h>
+
+static const float VEC3_EPSILON = 1e-8f;
+
+Vec3 vec3_make(float x, float y, float z) {
+  Vec3 vec = {x, y, z};
+  return vec;
+}
+
+Vec3 vec3_add(Vec3 lhs, Vec3 rhs) {
+  return vec3_make(lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z);
+}
+
+Vec3 vec3_sub(Vec3 lhs, Vec3 rhs) {
+  return vec3_make(lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z);
+}
+
+Vec3 vec3_scale(Vec3 vec, float scalar) {
+  return vec3_make(vec.x * scalar, vec.y * scalar, vec.z * scalar);
+}
+
+float vec3_dot(Vec3 lhs, Vec3 rhs) {
+  return lhs.x * rhs.x + lhs.y * rhs.y + lhs.z * rhs.z;
+}
+
+Vec3 vec3_cross(Vec3 lhs, Vec3 rhs) {
+  return vec3_make(lhs.y * rhs.z - lhs.z * rhs.y,
+                   lhs.z * rhs.x - lhs.x * rhs.z,
+                   lhs.x * rhs.y - lhs.y * rhs.x);
+}
+
+float vec3_length(Vec3 vec) { return sqrtf(vec3_dot(vec, vec)); }
+
+float vec3_distance(Vec3 lhs, Vec3 rhs) {
+  return vec3_length(vec3_sub(lhs, rhs));
+}
+
+bool vec3_normalize(Vec3 *vec) {
+  if (vec == NULL) {
+    return false;
+  }
+  float length = vec3_length(*vec);
+  if (length <= VEC3_EPSILON) {
+    return false;
+  }
+  const float inv = 1.0f / length;
+  vec->x *= inv;
+  vec->y *= inv;
+  vec->z *= inv;
+  return true;
+}
+
+Vec3 vec3_lerp(Vec3 lhs, Vec3 rhs, float t) {
+  return vec3_add(lhs, vec3_scale(vec3_sub(rhs, lhs), t));
+}
+
+Vec3 vec3_project(Vec3 vec, Vec3 onto) {
+  float denom = vec3_dot(onto, onto);
+  if (denom <= VEC3_EPSILON) {
+    return vec3_make(0.0f, 0.0f, 0.0f);
+  }
+  return vec3_scale(onto, vec3_dot(vec, onto) / denom);
+}
+
+Vec3 vec3_reflect(Vec3 incident, Vec3 normal) {
+  Vec3 n = normal;
+  if (!vec3_normalize(&n)) {
+    return incident;
+  }
+  return vec3_sub(incident, vec3_scale(n, 2.0f * vec3_dot(incident, n)));
+}

--- a/app/vector/src/vector_bridge.c
+++ b/app/vector/src/vector_bridge.c
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026 @tragisch <https://github.com/tragisch>
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "vector_bridge.h"
+
+#include <stddef.h>
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#endif
+#include <omp.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(USE_ACCELERATE)
+#define BLASINT int
+#include <Accelerate/Accelerate.h>
+#elif defined(USE_OPENBLAS)
+#define BLASINT int
+#include <cblas.h>
+#endif
+
+FloatVectorView sm_row_view(FloatMatrix *mat, size_t row) {
+  if (mat == NULL || mat->values == NULL || row >= mat->rows) {
+    return vv_make(NULL, 0, 0);
+  }
+  return vv_make(&mat->values[row * mat->cols], mat->cols, 1);
+}
+
+FloatVectorView sm_col_view(FloatMatrix *mat, size_t col) {
+  if (mat == NULL || mat->values == NULL || col >= mat->cols) {
+    return vv_make(NULL, 0, 0);
+  }
+  return vv_make(&mat->values[col], mat->rows, (ptrdiff_t)mat->cols);
+}
+
+FloatVector *sm_row_to_sv(const FloatMatrix *mat, size_t row) {
+  if (mat == NULL || mat->values == NULL || row >= mat->rows) {
+    return NULL;
+  }
+  return sv_create_with_values(mat->cols, &mat->values[row * mat->cols]);
+}
+
+FloatVector *sm_col_to_sv(const FloatMatrix *mat, size_t col) {
+  if (mat == NULL || mat->values == NULL || col >= mat->cols) {
+    return NULL;
+  }
+  FloatVector *vec = sv_create(mat->rows);
+  if (vec == NULL) {
+    return NULL;
+  }
+  for (size_t i = 0; i < mat->rows; ++i) {
+    vec->values[i] = mat->values[i * mat->cols + col];
+  }
+  return vec;
+}
+
+FloatVector *sm_matvec(const FloatMatrix *mat, const FloatVector *vec) {
+  if (mat == NULL || vec == NULL || mat->values == NULL || vec->values == NULL ||
+      mat->cols != vec->len) {
+    return NULL;
+  }
+  FloatVector *out = sv_create(mat->rows);
+  if (out == NULL) {
+    return NULL;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  cblas_sgemv(CblasRowMajor, CblasNoTrans, (BLASINT)mat->rows,
+              (BLASINT)mat->cols, 1.0f, mat->values, (BLASINT)mat->cols,
+              vec->values, 1, 0.0f, out->values, 1);
+#else
+#pragma omp parallel for
+  for (size_t i = 0; i < mat->rows; ++i) {
+    float sum = 0.0f;
+    for (size_t j = 0; j < mat->cols; ++j) {
+      sum += mat->values[i * mat->cols + j] * vec->values[j];
+    }
+    out->values[i] = sum;
+  }
+#endif
+  return out;
+}
+
+FloatMatrix *sv_outer_as_sm(const FloatVector *lhs, const FloatVector *rhs) {
+  if (lhs == NULL || rhs == NULL || lhs->values == NULL || rhs->values == NULL) {
+    return NULL;
+  }
+  FloatMatrix *out = sm_create(lhs->len, rhs->len);
+  if (out == NULL) {
+    return NULL;
+  }
+#pragma omp parallel for collapse(2)
+  for (size_t i = 0; i < lhs->len; ++i) {
+    for (size_t j = 0; j < rhs->len; ++j) {
+      out->values[i * rhs->len + j] = lhs->values[i] * rhs->values[j];
+    }
+  }
+  return out;
+}
+
+DoubleVector *dm_row_to_dv(const DoubleMatrix *mat, size_t row) {
+  if (mat == NULL || mat->values == NULL || row >= mat->rows) {
+    return NULL;
+  }
+  return dv_create_with_values(mat->cols, &mat->values[row * mat->cols]);
+}
+
+DoubleVector *dm_col_to_dv(const DoubleMatrix *mat, size_t col) {
+  if (mat == NULL || mat->values == NULL || col >= mat->cols) {
+    return NULL;
+  }
+  DoubleVector *vec = dv_create(mat->rows);
+  if (vec == NULL) {
+    return NULL;
+  }
+  for (size_t i = 0; i < mat->rows; ++i) {
+    vec->values[i] = mat->values[i * mat->cols + col];
+  }
+  return vec;
+}
+
+DoubleVector *dm_matvec(const DoubleMatrix *mat, const DoubleVector *vec) {
+  if (mat == NULL || vec == NULL || mat->values == NULL || vec->values == NULL ||
+      mat->cols != vec->len) {
+    return NULL;
+  }
+  DoubleVector *out = dv_create(mat->rows);
+  if (out == NULL) {
+    return NULL;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  cblas_dgemv(CblasRowMajor, CblasNoTrans, (BLASINT)mat->rows,
+              (BLASINT)mat->cols, 1.0, mat->values, (BLASINT)mat->cols,
+              vec->values, 1, 0.0, out->values, 1);
+#else
+#pragma omp parallel for
+  for (size_t i = 0; i < mat->rows; ++i) {
+    double sum = 0.0;
+    for (size_t j = 0; j < mat->cols; ++j) {
+      sum += mat->values[i * mat->cols + j] * vec->values[j];
+    }
+    out->values[i] = sum;
+  }
+#endif
+  return out;
+}
+
+DoubleMatrix *dv_outer_as_dm(const DoubleVector *lhs, const DoubleVector *rhs) {
+  if (lhs == NULL || rhs == NULL || lhs->values == NULL || rhs->values == NULL) {
+    return NULL;
+  }
+  DoubleMatrix *out = dm_create(lhs->len, rhs->len);
+  if (out == NULL) {
+    return NULL;
+  }
+#pragma omp parallel for collapse(2)
+  for (size_t i = 0; i < lhs->len; ++i) {
+    for (size_t j = 0; j < rhs->len; ++j) {
+      out->values[i * rhs->len + j] = lhs->values[i] * rhs->values[j];
+    }
+  }
+  return out;
+}
+
+DoubleSparseVector *dms_row_to_dvs(const DoubleSparseMatrix *mat, size_t row) {
+  if (mat == NULL || row >= mat->rows) {
+    return NULL;
+  }
+  DoubleSparseVector *vec = dvs_create(mat->cols, 0);
+  if (vec == NULL) {
+    return NULL;
+  }
+  for (size_t i = 0; i < mat->nnz; ++i) {
+    if (mat->row_indices[i] == row && !dvs_set(vec, mat->col_indices[i], mat->values[i])) {
+      dvs_destroy(vec);
+      return NULL;
+    }
+  }
+  if (!dvs_compact(vec)) {
+    dvs_destroy(vec);
+    return NULL;
+  }
+  return vec;
+}
+
+DoubleSparseVector *dms_col_to_dvs(const DoubleSparseMatrix *mat, size_t col) {
+  if (mat == NULL || col >= mat->cols) {
+    return NULL;
+  }
+  DoubleSparseVector *vec = dvs_create(mat->rows, 0);
+  if (vec == NULL) {
+    return NULL;
+  }
+  for (size_t i = 0; i < mat->nnz; ++i) {
+    if (mat->col_indices[i] == col && !dvs_set(vec, mat->row_indices[i], mat->values[i])) {
+      dvs_destroy(vec);
+      return NULL;
+    }
+  }
+  if (!dvs_compact(vec)) {
+    dvs_destroy(vec);
+    return NULL;
+  }
+  return vec;
+}

--- a/app/vector/src/vector_tensor_bridge.c
+++ b/app/vector/src/vector_tensor_bridge.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 @tragisch <https://github.com/tragisch>
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "vector_tensor_bridge.h"
+
+static FloatVectorView vv_invalid(void) { return vv_make(NULL, 0, 0); }
+
+FloatVectorView st_as_vv_view(FloatTensor *tensor) {
+  if (tensor == NULL || !st_is_contiguous(tensor) ||
+      st_tensor_dtype(tensor) != ST_DTYPE_F32) {
+    return vv_invalid();
+  }
+  return vv_make(st_tensor_mutable_data(tensor), st_tensor_numel(tensor), 1);
+}
+
+FloatVector *st_to_sv(const FloatTensor *tensor) {
+  if (tensor == NULL || !st_is_contiguous(tensor) ||
+      st_tensor_dtype(tensor) != ST_DTYPE_F32) {
+    return NULL;
+  }
+  return sv_create_with_values(st_tensor_numel(tensor), st_tensor_data(tensor));
+}

--- a/app/vector/src/vv.c
+++ b/app/vector/src/vv.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 @tragisch <https://github.com/tragisch>
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "vv.h"
+
+#include "sv.h"
+
+#include <limits.h>
+#include <math.h>
+#include <stddef.h>
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#endif
+#include <omp.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#if defined(USE_ACCELERATE)
+#define BLASINT int
+#include <Accelerate/Accelerate.h>
+#elif defined(USE_OPENBLAS)
+#define BLASINT int
+#include <cblas.h>
+#endif
+
+static bool vv_has_compatible_shape(const FloatVectorView *lhs,
+                                    const FloatVectorView *rhs) {
+  return vv_is_valid(lhs) && vv_is_valid(rhs) && lhs->len == rhs->len &&
+         lhs->stride > 0 && rhs->stride > 0;
+}
+
+FloatVectorView vv_make(float *data, size_t len, ptrdiff_t stride) {
+  FloatVectorView view;
+  view.len = len;
+  view.stride = stride;
+  view.values = data;
+  return view;
+}
+
+bool vv_is_valid(const FloatVectorView *view) {
+  return view != NULL && view->values != NULL && view->stride > 0;
+}
+
+float vv_get(const FloatVectorView *view, size_t index) {
+  if (!vv_is_valid(view) || index >= view->len) {
+    return 0.0f;
+  }
+  return view->values[index * (size_t)view->stride];
+}
+
+bool vv_set(FloatVectorView *view, size_t index, float value) {
+  if (!vv_is_valid(view) || index >= view->len) {
+    return false;
+  }
+  view->values[index * (size_t)view->stride] = value;
+  return true;
+}
+
+float vv_dot(const FloatVectorView *lhs, const FloatVectorView *rhs) {
+  if (!vv_has_compatible_shape(lhs, rhs)) {
+    return 0.0f;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  if (lhs->stride <= INT_MAX && rhs->stride <= INT_MAX && lhs->len <= INT_MAX) {
+    return cblas_sdot((BLASINT)lhs->len, lhs->values, (BLASINT)lhs->stride,
+                      rhs->values, (BLASINT)rhs->stride);
+  }
+#endif
+  float sum = 0.0f;
+#pragma omp parallel for simd reduction(+ : sum)
+  for (size_t i = 0; i < lhs->len; ++i) {
+    sum += lhs->values[i * (size_t)lhs->stride] *
+           rhs->values[i * (size_t)rhs->stride];
+  }
+  return sum;
+}
+
+float vv_norm_l2(const FloatVectorView *view) {
+  if (!vv_is_valid(view)) {
+    return 0.0f;
+  }
+#if defined(USE_ACCELERATE) || defined(USE_OPENBLAS)
+  if (view->stride <= INT_MAX && view->len <= INT_MAX) {
+    return cblas_snrm2((BLASINT)view->len, view->values, (BLASINT)view->stride);
+  }
+#endif
+  float sum = 0.0f;
+#pragma omp parallel for simd reduction(+ : sum)
+  for (size_t i = 0; i < view->len; ++i) {
+    const float value = view->values[i * (size_t)view->stride];
+    sum += value * value;
+  }
+  return sqrtf(sum);
+}
+
+FloatVector *vv_to_sv(const FloatVectorView *view) {
+  if (!vv_is_valid(view)) {
+    return NULL;
+  }
+  FloatVector *vec = sv_create(view->len);
+  if (vec == NULL) {
+    return NULL;
+  }
+  for (size_t i = 0; i < view->len; ++i) {
+    vec->values[i] = view->values[i * (size_t)view->stride];
+  }
+  return vec;
+}
+
+bool vv_copy_from_sv(FloatVectorView *dst, const FloatVector *src) {
+  if (!vv_is_valid(dst) || src == NULL || src->values == NULL ||
+      dst->len != src->len) {
+    return false;
+  }
+  for (size_t i = 0; i < dst->len; ++i) {
+    dst->values[i * (size_t)dst->stride] = src->values[i];
+  }
+  return true;
+}

--- a/app/vector/tests/bench_sv_dv.c
+++ b/app/vector/tests/bench_sv_dv.c
@@ -1,0 +1,226 @@
+/*
+ * Benchmark: sv / dv wrapper vs. Accelerate direct calls
+ *
+ * Measures overhead of our FloatVector / DoubleVector API compared to calling
+ * cblas_sdot / cblas_ddot / cblas_saxpy / cblas_snrm2 directly via Accelerate.
+ *
+ * Build & run:
+ *   bazel run --define MATRIX_BACKEND=accelerate //app/vector:bench_sv_dv
+ */
+
+#include "dv.h"
+#include "sv.h"
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#if defined(USE_ACCELERATE)
+#include <Accelerate/Accelerate.h>
+#define HAVE_BLAS 1
+#elif defined(USE_OPENBLAS)
+#include <cblas.h>
+#define HAVE_BLAS 1
+#else
+#define HAVE_BLAS 0
+#endif
+
+/* ---- timing ------------------------------------------------------------ */
+
+static uint64_t now_ns(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+}
+
+/* ---- helpers ----------------------------------------------------------- */
+
+static void fill_rand_f(float *buf, size_t n, uint32_t seed) {
+  for (size_t i = 0; i < n; i++) {
+    seed = seed * 1664525u + 1013904223u;
+    buf[i] = ((float)(seed >> 8) / 16777216.0f) - 0.5f;
+  }
+}
+
+static void fill_rand_d(double *buf, size_t n, uint32_t seed) {
+  for (size_t i = 0; i < n; i++) {
+    seed = seed * 1664525u + 1013904223u;
+    buf[i] = ((double)(seed >> 8) / 16777216.0) - 0.5;
+  }
+}
+
+/* ---- benchmark runner -------------------------------------------------- */
+
+#define WARMUP 5
+#define ITERS  200
+
+typedef double (*BenchFn)(void *ctx);
+
+static double run_bench(BenchFn fn, void *ctx, const char *label,
+                        size_t n_elems) {
+  /* warmup */
+  for (int i = 0; i < WARMUP; i++) fn(ctx);
+
+  uint64_t t0 = now_ns();
+  volatile double sink = 0.0;
+  for (int i = 0; i < ITERS; i++) sink += fn(ctx);
+  uint64_t t1 = now_ns();
+  (void)sink;
+
+  double ms_per_iter = (double)(t1 - t0) / 1e6 / ITERS;
+  double gb_s = (double)n_elems * sizeof(float) / 1e9 / (ms_per_iter / 1000.0);
+  printf("  %-36s  %7.3f ms/iter  %6.2f GB/s\n", label, ms_per_iter, gb_s);
+  return ms_per_iter;
+}
+
+/* ======================================================================== */
+/* sv_dot  ----------------------------------------------------------------- */
+
+typedef struct { FloatVector *a; FloatVector *b; } SvPair;
+typedef struct { float *a; float *b; int n; } RawPair;
+
+static double bench_sv_dot(void *ctx) {
+  SvPair *p = ctx;
+  return (double)sv_dot(p->a, p->b);
+}
+
+#if HAVE_BLAS
+static double bench_raw_sdot(void *ctx) {
+  RawPair *p = ctx;
+  return (double)cblas_sdot(p->n, p->a, 1, p->b, 1);
+}
+#endif
+
+/* sv_axpy ----------------------------------------------------------------- */
+
+typedef struct { FloatVector *dst; FloatVector *src; } SvAxpyCtx;
+typedef struct { float *dst; float *src; int n; } RawAxpyCtx;
+
+static double bench_sv_axpy(void *ctx) {
+  SvAxpyCtx *p = ctx;
+  sv_axpy(p->dst, 2.0f, p->src);
+  return 0.0;
+}
+
+#if HAVE_BLAS
+static double bench_raw_saxpy(void *ctx) {
+  RawAxpyCtx *p = ctx;
+  cblas_saxpy(p->n, 2.0f, p->src, 1, p->dst, 1);
+  return 0.0;
+}
+#endif
+
+/* sv_norm_l2 -------------------------------------------------------------- */
+
+typedef struct { FloatVector *v; } SvNormCtx;
+
+static double bench_sv_norm(void *ctx) {
+  SvNormCtx *p = ctx;
+  return (double)sv_norm_l2(p->v);
+}
+
+#if HAVE_BLAS
+typedef struct { float *v; int n; } RawNormCtx;
+static double bench_raw_snrm2(void *ctx) {
+  RawNormCtx *p = ctx;
+  return (double)cblas_snrm2(p->n, p->v, 1);
+}
+#endif
+
+/* dv_dot ------------------------------------------------------------------ */
+
+typedef struct { DoubleVector *a; DoubleVector *b; } DvPair;
+
+static double bench_dv_dot(void *ctx) {
+  DvPair *p = ctx;
+  return dv_dot(p->a, p->b);
+}
+
+#if HAVE_BLAS
+typedef struct { double *a; double *b; int n; } RawDPair;
+static double bench_raw_ddot(void *ctx) {
+  RawDPair *p = ctx;
+  return cblas_ddot(p->n, p->a, 1, p->b, 1);
+}
+#endif
+
+/* ======================================================================== */
+
+int main(void) {
+  const size_t sizes[] = {256, 4096, 65536, 1048576};
+  const int    nsizes  = (int)(sizeof(sizes) / sizeof(sizes[0]));
+
+  printf("bench_sv_dv  —  wrapper overhead vs. Accelerate direct\n");
+  printf("WARMUP=%d  ITERS=%d\n\n", WARMUP, ITERS);
+
+#if !HAVE_BLAS
+  printf("WARNING: no BLAS backend — direct calls not available.\n"
+         "Build with --define MATRIX_BACKEND=accelerate\n\n");
+#endif
+
+  for (int si = 0; si < nsizes; si++) {
+    size_t n = sizes[si];
+    printf("──── n = %zu ────────────────────────────────────────────\n", n);
+
+    /* allocate raw buffers */
+    float  *fa = malloc(n * sizeof(float));
+    float  *fb = malloc(n * sizeof(float));
+    double *da = malloc(n * sizeof(double));
+    double *db = malloc(n * sizeof(double));
+    fill_rand_f(fa, n, 0xDEAD1234u);
+    fill_rand_f(fb, n, 0xBEEF5678u);
+    fill_rand_d(da, n, 0xCAFEBABEu);
+    fill_rand_d(db, n, 0xF00DC0DEu);
+
+    /* wrap in our types (we own the data — use create_with_values to copy) */
+    FloatVector  *sva = sv_create_with_values(n, fa);
+    FloatVector  *svb = sv_create_with_values(n, fb);
+    DoubleVector *dva = dv_create_with_values(n, da);
+    DoubleVector *dvb = dv_create_with_values(n, db);
+
+    /* --- dot --- */
+    SvPair sv_pair = {sva, svb};
+    run_bench(bench_sv_dot, &sv_pair, "sv_dot (wrapper)", n * 2);
+#if HAVE_BLAS
+    RawPair raw_pair = {fa, fb, (int)n};
+    run_bench(bench_raw_sdot, &raw_pair, "cblas_sdot (direct)", n * 2);
+#endif
+
+    /* --- axpy --- */
+    SvAxpyCtx sv_axpy_ctx = {sva, svb};
+    run_bench(bench_sv_axpy, &sv_axpy_ctx, "sv_axpy (wrapper)", n * 3);
+#if HAVE_BLAS
+    float  *axpy_dst = malloc(n * sizeof(float));
+    memcpy(axpy_dst, fa, n * sizeof(float));
+    RawAxpyCtx raw_axpy = {axpy_dst, fb, (int)n};
+    run_bench(bench_raw_saxpy, &raw_axpy, "cblas_saxpy (direct)", n * 3);
+    free(axpy_dst);
+#endif
+
+    /* --- norm --- */
+    SvNormCtx sv_norm_ctx = {sva};
+    run_bench(bench_sv_norm, &sv_norm_ctx, "sv_norm_l2 (wrapper)", n);
+#if HAVE_BLAS
+    RawNormCtx raw_norm = {fa, (int)n};
+    run_bench(bench_raw_snrm2, &raw_norm, "cblas_snrm2 (direct)", n);
+#endif
+
+    /* --- dv_dot --- */
+    DvPair dv_pair = {dva, dvb};
+    run_bench(bench_dv_dot, &dv_pair, "dv_dot (wrapper)", n * 2);
+#if HAVE_BLAS
+    RawDPair raw_dpair = {da, db, (int)n};
+    run_bench(bench_raw_ddot, &raw_dpair, "cblas_ddot (direct)", n * 2);
+#endif
+
+    sv_destroy(sva);
+    sv_destroy(svb);
+    dv_destroy(dva);
+    dv_destroy(dvb);
+    free(fa); free(fb); free(da); free(db);
+    printf("\n");
+  }
+  return 0;
+}

--- a/app/vector/tests/my_config.yml
+++ b/app/vector/tests/my_config.yml
@@ -1,0 +1,6 @@
+:unity:
+  :includes:
+    - stdio.h
+  :cexception: 0
+  :use_param_tests: 1
+  :cmdline_args: 1

--- a/app/vector/tests/test_dv.c
+++ b/app/vector/tests/test_dv.c
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "dv.h"
+
+#include <math.h>
+
+#define TEST_CASE(...)
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_dv_dot_and_scale_should_work(void) {
+  const double lhs_values[] = {1.0, 2.0, 3.0};
+  const double rhs_values[] = {4.0, 5.0, 6.0};
+  DoubleVector *lhs = dv_create_with_values(3, lhs_values);
+  DoubleVector *rhs = dv_create_with_values(3, rhs_values);
+  DoubleVector *scaled = dv_scale(lhs, 0.5);
+
+  TEST_ASSERT_NOT_NULL(lhs);
+  TEST_ASSERT_NOT_NULL(rhs);
+  TEST_ASSERT_NOT_NULL(scaled);
+  TEST_ASSERT_TRUE(fabs(dv_dot(lhs, rhs) - 32.0) < 1e-10);
+  TEST_ASSERT_TRUE(fabs(scaled->values[0] - 0.5) < 1e-10);
+  TEST_ASSERT_TRUE(fabs(scaled->values[1] - 1.0) < 1e-10);
+  TEST_ASSERT_TRUE(fabs(scaled->values[2] - 1.5) < 1e-10);
+
+  dv_destroy(scaled);
+  dv_destroy(rhs);
+  dv_destroy(lhs);
+}
+
+void test_dv_axpy_and_normalize_should_work(void) {
+  const double src_values[] = {1.0, 0.0, 0.0};
+  const double dst_values[] = {0.0, 2.0, 0.0};
+  DoubleVector *src = dv_create_with_values(3, src_values);
+  DoubleVector *dst = dv_create_with_values(3, dst_values);
+
+  TEST_ASSERT_TRUE(dv_axpy(dst, 3.0, src));
+  TEST_ASSERT_TRUE(fabs(dst->values[0] - 3.0) < 1e-10);
+  TEST_ASSERT_TRUE(fabs(dst->values[1] - 2.0) < 1e-10);
+  TEST_ASSERT_TRUE(dv_normalize(dst));
+  TEST_ASSERT_TRUE(fabs(dv_norm_l2(dst) - 1.0) < 1e-10);
+
+  dv_destroy(dst);
+  dv_destroy(src);
+}

--- a/app/vector/tests/test_dvs.c
+++ b/app/vector/tests/test_dvs.c
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "dv.h"
+#include "dvs.h"
+
+#include <math.h>
+#include <stdint.h>
+
+#define TEST_CASE(...)
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_dvs_set_get_and_compact_should_work(void) {
+  DoubleSparseVector *vec = dvs_create(8, 2);
+  TEST_ASSERT_NOT_NULL(vec);
+
+  TEST_ASSERT_TRUE(dvs_set(vec, 3, 2.5));
+  TEST_ASSERT_TRUE(dvs_set(vec, 1, 1.5));
+  TEST_ASSERT_TRUE(dvs_set(vec, 3, 4.5));
+  TEST_ASSERT_TRUE(fabs(dvs_get(vec, 1) - 1.5) < 1e-10);
+  TEST_ASSERT_TRUE(fabs(dvs_get(vec, 3) - 4.5) < 1e-10);
+  TEST_ASSERT_TRUE(dvs_sort_indices(vec));
+  TEST_ASSERT_TRUE(dvs_compact(vec));
+  TEST_ASSERT_EQUAL_UINT32(2, (uint32_t)vec->nnz);
+
+  dvs_destroy(vec);
+}
+
+void test_dvs_add_and_dot_dense_should_work(void) {
+  DoubleSparseVector *lhs = dvs_create(4, 2);
+  DoubleSparseVector *rhs = dvs_create(4, 2);
+  TEST_ASSERT_TRUE(dvs_set(lhs, 0, 1.0));
+  TEST_ASSERT_TRUE(dvs_set(lhs, 2, 3.0));
+  TEST_ASSERT_TRUE(dvs_set(rhs, 2, 4.0));
+  TEST_ASSERT_TRUE(dvs_set(rhs, 3, 5.0));
+
+  DoubleSparseVector *sum = dvs_add(lhs, rhs);
+  /* sum = {0:1, 2:7, 3:5}, dense = {2, 0, 10, 1} => dot = 1*2 + 7*10 + 5*1 = 77 */
+  const double dense_values[] = {2.0, 0.0, 10.0, 1.0};
+  DoubleVector *dense = dv_create_with_values(4, dense_values);
+
+  TEST_ASSERT_NOT_NULL(sum);
+  TEST_ASSERT_TRUE(fabs(dvs_get(sum, 0) - 1.0) < 1e-10);
+  TEST_ASSERT_TRUE(fabs(dvs_get(sum, 2) - 7.0) < 1e-10);
+  TEST_ASSERT_TRUE(fabs(dvs_get(sum, 3) - 5.0) < 1e-10);
+  TEST_ASSERT_TRUE(fabs(dvs_dot_dense(sum, dense) - 77.0) < 1e-10);
+
+  dv_destroy(dense);
+  dvs_destroy(sum);
+  dvs_destroy(rhs);
+  dvs_destroy(lhs);
+}

--- a/app/vector/tests/test_sv.c
+++ b/app/vector/tests/test_sv.c
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "sv.h"
+
+#include <stdint.h>
+
+#define UNITY_INCLUDE_FLOAT
+#define UNITY_FLOAT_PRECISION 5
+#define TEST_CASE(...)
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_sv_create_should_zero_initialize(void) {
+  FloatVector *vec = sv_create(4);
+  TEST_ASSERT_NOT_NULL(vec);
+  TEST_ASSERT_EQUAL_UINT32(4, (uint32_t)vec->len);
+  for (size_t i = 0; i < vec->len; ++i) {
+    TEST_ASSERT_FLOAT_WITHIN(1e-6f, 0.0f, vec->values[i]);
+  }
+  sv_destroy(vec);
+}
+
+void test_sv_add_dot_and_axpy_should_work(void) {
+  const float lhs_values[] = {1.0f, 2.0f, 3.0f};
+  const float rhs_values[] = {4.0f, 5.0f, 6.0f};
+  FloatVector *lhs = sv_create_with_values(3, lhs_values);
+  FloatVector *rhs = sv_create_with_values(3, rhs_values);
+  FloatVector *sum = sv_add(lhs, rhs);
+
+  TEST_ASSERT_NOT_NULL(sum);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 5.0f, sum->values[0]);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 7.0f, sum->values[1]);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 9.0f, sum->values[2]);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 32.0f, sv_dot(lhs, rhs));
+
+  TEST_ASSERT_TRUE(sv_axpy(lhs, 2.0f, rhs));
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 9.0f, lhs->values[0]);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 12.0f, lhs->values[1]);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 15.0f, lhs->values[2]);
+
+  sv_destroy(sum);
+  sv_destroy(rhs);
+  sv_destroy(lhs);
+}
+
+void test_sv_normalize_and_softmax_should_work(void) {
+  const float norm_values[] = {3.0f, 4.0f};
+  FloatVector *norm_vec = sv_create_with_values(2, norm_values);
+  TEST_ASSERT_TRUE(sv_normalize(norm_vec));
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 0.6f, norm_vec->values[0]);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 0.8f, norm_vec->values[1]);
+  sv_destroy(norm_vec);
+
+  const float softmax_values[] = {1.0f, 2.0f, 3.0f};
+  FloatVector *softmax_vec = sv_create_with_values(3, softmax_values);
+  TEST_ASSERT_TRUE(sv_softmax(softmax_vec));
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 1.0f, sv_sum(softmax_vec));
+  TEST_ASSERT_EQUAL_UINT32(2, (uint32_t)sv_argmax(softmax_vec));
+  sv_destroy(softmax_vec);
+}

--- a/app/vector/tests/test_vec3.c
+++ b/app/vector/tests/test_vec3.c
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "vec3.h"
+
+#define UNITY_INCLUDE_FLOAT
+#define UNITY_FLOAT_PRECISION 5
+#define TEST_CASE(...)
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_vec3_cross_and_dot_should_work(void) {
+  Vec3 x = vec3_make(1.0f, 0.0f, 0.0f);
+  Vec3 y = vec3_make(0.0f, 1.0f, 0.0f);
+  Vec3 z = vec3_cross(x, y);
+
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 0.0f, vec3_dot(x, y));
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 0.0f, z.x);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 0.0f, z.y);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 1.0f, z.z);
+}
+
+void test_vec3_normalize_project_and_reflect_should_work(void) {
+  Vec3 v = vec3_make(3.0f, 4.0f, 0.0f);
+  Vec3 onto = vec3_make(1.0f, 0.0f, 0.0f);
+  Vec3 incident = vec3_make(1.0f, -1.0f, 0.0f);
+  Vec3 normal = vec3_make(0.0f, 1.0f, 0.0f);
+
+  TEST_ASSERT_TRUE(vec3_normalize(&v));
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 1.0f, vec3_length(v));
+
+  Vec3 projected = vec3_project(vec3_make(2.0f, 3.0f, 0.0f), onto);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 2.0f, projected.x);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 0.0f, projected.y);
+
+  Vec3 reflected = vec3_reflect(incident, normal);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 1.0f, reflected.x);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 1.0f, reflected.y);
+}

--- a/app/vector/tests/test_vector_bridge.c
+++ b/app/vector/tests/test_vector_bridge.c
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "sm.h"
+#include "st.h"
+#include "sv.h"
+#include "vector_bridge.h"
+#include "vector_tensor_bridge.h"
+
+#include <stdint.h>
+
+#define UNITY_INCLUDE_FLOAT
+#define UNITY_FLOAT_PRECISION 5
+#define TEST_CASE(...)
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_vector_bridge_sm_matvec_and_outer_should_work(void) {
+  FloatMatrix *mat = sm_create(2, 3);
+  const float vec_values[] = {1.0f, 2.0f, 3.0f};
+  const float rhs_values[] = {4.0f, 5.0f};
+  FloatVector *vec = sv_create_with_values(3, vec_values);
+  FloatVector *rhs = sv_create_with_values(2, rhs_values);
+  TEST_ASSERT_NOT_NULL(mat);
+  mat->values[0] = 1.0f;
+  mat->values[1] = 0.0f;
+  mat->values[2] = 2.0f;
+  mat->values[3] = 0.0f;
+  mat->values[4] = 1.0f;
+  mat->values[5] = 3.0f;
+
+  FloatVector *product = sm_matvec(mat, vec);
+  FloatMatrix *outer = sv_outer_as_sm(rhs, vec);
+
+  TEST_ASSERT_NOT_NULL(product);
+  TEST_ASSERT_NOT_NULL(outer);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 7.0f, product->values[0]);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 11.0f, product->values[1]);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 4.0f, outer->values[0]);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 10.0f, outer->values[4]);
+
+  sm_destroy(outer);
+  sv_destroy(product);
+  sv_destroy(rhs);
+  sv_destroy(vec);
+  sm_destroy(mat);
+}
+
+void test_vector_bridge_tensor_view_should_flatten_contiguous_tensor(void) {
+  const size_t shape[] = {2, 2};
+  FloatTensor *tensor = st_create(2, shape);
+  TEST_ASSERT_NOT_NULL(tensor);
+
+  size_t idx00[] = {0, 0};
+  size_t idx01[] = {0, 1};
+  size_t idx10[] = {1, 0};
+  size_t idx11[] = {1, 1};
+  TEST_ASSERT_TRUE(st_set(tensor, idx00, 1.0f));
+  TEST_ASSERT_TRUE(st_set(tensor, idx01, 2.0f));
+  TEST_ASSERT_TRUE(st_set(tensor, idx10, 3.0f));
+  TEST_ASSERT_TRUE(st_set(tensor, idx11, 4.0f));
+
+  FloatVectorView view = st_as_vv_view(tensor);
+  TEST_ASSERT_TRUE(vv_is_valid(&view));
+  TEST_ASSERT_EQUAL_UINT32(4, (uint32_t)view.len);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 3.0f, vv_get(&view, 2));
+
+  FloatVector *copy = st_to_sv(tensor);
+  TEST_ASSERT_NOT_NULL(copy);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 4.0f, copy->values[3]);
+
+  sv_destroy(copy);
+  st_destroy(tensor);
+}

--- a/app/vector/tests/test_vv.c
+++ b/app/vector/tests/test_vv.c
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "sm.h"
+#include "sv.h"
+#include "vector_bridge.h"
+#include "vv.h"
+
+#include <stdint.h>
+
+#define UNITY_INCLUDE_FLOAT
+#define UNITY_FLOAT_PRECISION 5
+#define TEST_CASE(...)
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_vv_should_expose_row_and_column_views(void) {
+  FloatMatrix *mat = sm_create(2, 3);
+  TEST_ASSERT_NOT_NULL(mat);
+  mat->values[0] = 1.0f;
+  mat->values[1] = 2.0f;
+  mat->values[2] = 3.0f;
+  mat->values[3] = 4.0f;
+  mat->values[4] = 5.0f;
+  mat->values[5] = 6.0f;
+
+  FloatVectorView row = sm_row_view(mat, 1);
+  FloatVectorView col = sm_col_view(mat, 1);
+
+  TEST_ASSERT_TRUE(vv_is_valid(&row));
+  TEST_ASSERT_TRUE(vv_is_valid(&col));
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 4.0f, vv_get(&row, 0));
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 5.0f, vv_get(&row, 1));
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 2.0f, vv_get(&col, 0));
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 5.0f, vv_get(&col, 1));
+
+  FloatVector *materialized = vv_to_sv(&col);
+  TEST_ASSERT_NOT_NULL(materialized);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 29.0f, vv_dot(&col, &col));
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 2.0f, materialized->values[0]);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 5.0f, materialized->values[1]);
+
+  sv_destroy(materialized);
+  sm_destroy(mat);
+}
+
+void test_vv_copy_from_sv_should_write_back(void) {
+  float data[] = {1.0f, 2.0f, 3.0f};
+  FloatVectorView view = vv_make(data, 3, 1);
+  const float replacement[] = {7.0f, 8.0f, 9.0f};
+  FloatVector *vec = sv_create_with_values(3, replacement);
+
+  TEST_ASSERT_TRUE(vv_copy_from_sv(&view, vec));
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 7.0f, data[0]);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 8.0f, data[1]);
+  TEST_ASSERT_FLOAT_WITHIN(1e-5f, 9.0f, data[2]);
+
+  sv_destroy(vec);
+}


### PR DESCRIPTION
## Was wurde hinzugefügt?

Neues Modul `app/vector` mit 5 Vektortypen, das `app/matrix` und `app/tensor` ergänzt.

### Vektortypen

| Typ | Datei | Beschreibung |
|-----|-------|--------------|
| `sv` | `src/sv.c` | Dense Float-Vektor (Accelerate/OpenBLAS + OpenMP) |
| `dv` | `src/dv.c` | Dense Double-Vektor (Accelerate/OpenBLAS + OpenMP) |
| `vv` | `src/vv.c` | Strided Float-View (non-owning, zero-copy) |
| `dvs` | `src/dvs.c` | COO Sparse Double-Vektor |
| `vec3` | `src/vec3.c` | Fester 3D-Geometrie-Vektor (cross, dot, lerp, reflect, project) |

### Brücken-Layer

- `vector_bridge` — Matrix↔Vector-Konvertierung (sm/dm/dms)
- `vector_tensor_bridge` — Tensor↔Vector-Brücke (macOS only, separates Target)

### Performance

Gleiches Backend-Pattern wie `app/matrix`:
- macOS: Accelerate (`-framework Accelerate`, `-DUSE_ACCELERATE`)
- Linux: OpenBLAS (`-DUSE_OPENBLAS`)
- `-O3 -march=native -fvectorize -ffast-math`

### Benchmark

```
bazel run --define MATRIX_BACKEND=accelerate //app/vector:bench_sv_dv
```

**Ergebnis (Apple M-Serie, n=1M):** ~0% Overhead gegenüber direktem Accelerate.

| Operation | Wrapper | Direct Accelerate |
|-----------|---------|-------------------|
| sv_dot    | 0.011 ms | 0.011 ms |
| sv_axpy   | 0.035 ms | 0.035 ms |
| sv_norm_l2 | 0.146 ms | 0.146 ms |
| dv_dot    | 0.136 ms | 0.151 ms |

### Tests

6/6 Tests grün (`test_sv`, `test_dv`, `test_vv`, `test_dvs`, `test_vec3`, `test_vector_bridge`):

```
bazel test --define MATRIX_BACKEND=accelerate //app/vector:all
```